### PR TITLE
🎉 Bind K and J to emoji picker

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,24 +40,14 @@ fn select_emoji() -> Option<&'static str> {
     let mut aborted = false;
     let mut selected = CommitType::Breaking;
 
-    fn next_or_first(commit: CommitType) -> CommitType {
-        commit.prev_variant().unwrap_or(CommitType::last_variant())
-    }
-
-    fn prev_or_last(commit: CommitType) -> CommitType {
-        commit.next_variant().unwrap_or(CommitType::first_variant())
-    }
-
     loop {
         print_emoji_selector(&mut log_update, &selected);
 
         match key_stream.next().unwrap().unwrap() {
             Key::Ctrl('c') => { aborted = true; break },
             Key::Char('\n') => break,
-            Key::Up => selected = next_or_first(selected),
-            Key::Down => selected = prev_or_last(selected),
-            Key::Char('k') => selected = next_or_first(selected),
-            Key::Char('j') => selected = prev_or_last(selected),
+            Key::Up | Key::Char('k') | Key::Char('K') => selected = selected.prev_variant().unwrap_or(CommitType::last_variant()),
+            Key::Down | Key::Char('j') | Key::Char('J') => selected = selected.next_variant().unwrap_or(CommitType::first_variant()),
             _ => {},
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,16 +40,24 @@ fn select_emoji() -> Option<&'static str> {
     let mut aborted = false;
     let mut selected = CommitType::Breaking;
 
+    fn next_or_first(commit: CommitType) -> CommitType {
+        commit.prev_variant().unwrap_or(CommitType::last_variant())
+    }
+
+    fn prev_or_last(commit: CommitType) -> CommitType {
+        commit.next_variant().unwrap_or(CommitType::first_variant())
+    }
+
     loop {
         print_emoji_selector(&mut log_update, &selected);
 
         match key_stream.next().unwrap().unwrap() {
             Key::Ctrl('c') => { aborted = true; break },
             Key::Char('\n') => break,
-            Key::Up => selected = selected.prev_variant().unwrap_or(CommitType::last_variant()),
-            Key::Down => selected = selected.next_variant().unwrap_or(CommitType::first_variant()),
-            Key::Char('k') => selected = selected.prev_variant().unwrap_or(CommitType::last_variant()),
-            Key::Char('j') => selected = selected.next_variant().unwrap_or(CommitType::first_variant()),
+            Key::Up => selected = next_or_first(selected),
+            Key::Down => selected = prev_or_last(selected),
+            Key::Char('k') => selected = next_or_first(selected),
+            Key::Char('j') => selected = prev_or_last(selected),
             _ => {},
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,8 @@ fn select_emoji() -> Option<&'static str> {
             Key::Char('\n') => break,
             Key::Up => selected = selected.prev_variant().unwrap_or(CommitType::last_variant()),
             Key::Down => selected = selected.next_variant().unwrap_or(CommitType::first_variant()),
+            Key::Char('k') => selected = selected.prev_variant().unwrap_or(CommitType::last_variant()),
+            Key::Char('j') => selected = selected.next_variant().unwrap_or(CommitType::first_variant()),
             _ => {},
         }
     }


### PR DESCRIPTION
Fix #4

Two potential improvements:
- `Key::Char('k')` will only match lowercase k, so if you have caps lock on you can't navigate, feature or bug? 🤔 
- Should i make up/down selected a function and share it between all the keys that do the same thing or is this good enough?

Both are fixed 👍 