### PR TITLE
🐛 Do not overwrite non-empty git commit messages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ fn git_message_is_empty(git_commit_contents: & String) -> bool {
 }
 
 fn collect_information_and_write_to_file(out_path: PathBuf) {
-    let mut file = File::open(out_path.clone().into_os_string().into_string().unwrap()).unwrap();
+    let mut file = File::open(&out_path).unwrap();
     let mut contents = String::new();
     file.read_to_string(&mut contents).expect("Failed to read from file");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ fn launch_git_with_self_as_editor() {
 }
 
 fn git_message_is_empty(git_commit_contents: & String) -> bool {
-    for line in git_commit_contents.split("\n") {
+    for line in git_commit_contents.lines() {
         if !line.starts_with('#') && line.len() > 0  {
             return false;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn launch_git_with_self_as_editor() {
     run_cmd(Command::new("git").arg("commit").env("GIT_EDITOR", self_path))
 }
 
-fn git_message_is_empty(git_commit_contents: & String) -> bool {
+fn git_message_is_empty(git_commit_contents: &str) -> bool {
     for line in git_commit_contents.lines() {
         if !line.starts_with('#') && line.len() > 0  {
             return false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,34 +158,34 @@ fn git_message_is_empty(file: &mut File) -> bool {
 fn collect_information_and_write_to_file(out_path: PathBuf) {
     let mut file = File::open(&out_path).unwrap();
 
-    if git_message_is_empty(&mut file) {
-        let maybe_emoji = select_emoji();
-        if maybe_emoji == None {
+    if !git_message_is_empty(&mut file) {
+        launch_default_editor(out_path);
+        return;
+    }
+
+    let maybe_emoji = select_emoji();
+    if maybe_emoji == None {
+        abort();
+    }
+
+    if let Some(emoji) = maybe_emoji {
+        let mut launch_editor = false;
+        let maybe_message = collect_commit_message(emoji, &mut launch_editor);
+        if maybe_message == None {
             abort();
         }
 
-        if let Some(emoji) = maybe_emoji {
-            let mut launch_editor = false;
-            let maybe_message = collect_commit_message(emoji, &mut launch_editor);
-            if maybe_message == None {
-                abort();
-            }
+        if let Some(message) = maybe_message {
+            let result = format!("{} {}\n", emoji, message);
 
+            let mut f = File::create(out_path.clone()).unwrap();
+            f.write_all(result.as_bytes()).unwrap();
+            drop(f);
 
-            if let Some(message) = maybe_message {
-                let result = format!("{} {}\n", emoji, message);
-
-                let mut f = File::create(out_path.clone()).unwrap();
-                f.write_all(result.as_bytes()).unwrap();
-                drop(f);
-
-                if launch_editor {
-                    launch_default_editor(out_path);
-                }
+            if launch_editor {
+                launch_default_editor(out_path);
             }
         }
-    } else {
-        launch_default_editor(out_path);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::error::Error;
 use std::fmt;
 use std::fs::File;
-use std::io::{BufRead, BufReader, Write, stderr, stdin};
+use std::io::{BufRead, BufReader, Seek, Write, stderr, stdin};
 use std::process::{Command, exit};
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -178,9 +178,10 @@ fn collect_information_and_write_to_file(out_path: PathBuf) {
         if let Some(message) = maybe_message {
             let result = format!("{} {}\n", emoji, message);
 
-            let mut f = File::create(out_path.clone()).unwrap();
-            f.write_all(result.as_bytes()).unwrap();
-            drop(f);
+            file.set_len(0).unwrap();
+            file.rewind().unwrap();
+            file.write_all(result.as_bytes()).unwrap();
+            drop(file);
 
             if launch_editor {
                 launch_default_editor(out_path);

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn launch_git_with_self_as_editor() {
 
 fn git_message_is_empty(git_commit_contents: &str) -> bool {
     for line in git_commit_contents.lines() {
-        if !line.starts_with('#') && line.len() > 0  {
+        if !line.starts_with('#') && !line.is_empty()  {
             return false;
         }
     }


### PR DESCRIPTION
If a commit message is not empty, it will launch the default editor to
give the user the option to edit or keep the current message. Described
in more detail in https://github.com/LinusU/emoji-commit/issues/15.