### PR TITLE
🎉 Add editor input navigation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "termion"
-version = "1.5.6"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077185e2eac69c3f8379a4298e1e07cd36beb962290d4a51199acf0fdc10607e"
+checksum = "659c1f379f3408c7e5e84c7d0da6d93404e3800b6b9d063ba24436419302ec90"
 dependencies = [
  "libc",
  "numtoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "readme.md"
 license = "MIT"
 
 [dependencies]
-termion = "1.0"
+termion = "2.0.1"
 log-update = "~0.1.0"
 default-editor = "~0.1.0"
 emoji-commit-type = "~0.1.1"

--- a/src/input_string.rs
+++ b/src/input_string.rs
@@ -1,0 +1,176 @@
+use ansi_term::Colour::White;
+
+pub struct InputString {
+    value: String,
+    position: usize,
+    is_control_input: bool,
+}
+
+impl InputString {
+    pub fn new() -> Self {
+        Self {
+            value: String::new(),
+            position: 0,
+            is_control_input: false,
+        }
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.value.as_str()
+    }
+
+    pub fn trim(&self) -> &str {
+        self.value.trim()
+    }
+    pub fn push(&mut self, c: char) {
+        if self.is_control_input {
+            self.handle_control(c);
+            return;
+        }
+        if self.position == self.value.len() {
+            self.value.push(c);
+        } else {
+            let mut new_string = String::new();
+            new_string.push_str(&self.value.as_str()[0..self.position]);
+            new_string.push(c);
+            new_string.push_str(&self.value.as_str()[self.position..]);
+            self.value = new_string;
+        }
+        self.position += 1;
+    }
+
+    pub fn delete(&mut self) {
+        if self.position == self.value.len() {
+            return;
+        }
+        if self.position == 0 {
+            self.value.remove(0);
+        } else {
+            let mut new_string = String::new();
+            new_string.push_str(&self.value.as_str()[0..self.position]);
+            new_string.push_str(&self.value.as_str()[self.position + 1..]);
+            self.value = new_string;
+        }
+    }
+
+    pub fn backspace(&mut self) {
+        if self.position == 0 {
+            return;
+        }
+        if self.position == self.value.len() {
+            self.value.pop();
+        } else {
+            let mut new_string = String::new();
+            new_string.push_str(&self.value.as_str()[0..self.position - 1]);
+            new_string.push_str(&self.value.as_str()[self.position..]);
+            self.value = new_string;
+        }
+        self.position -= 1;
+    }
+
+    pub fn go_char_left(&mut self) {
+        if self.position > 1 {
+            self.position -= 1;
+        } else {
+            self.position = 0;
+        }
+    }
+    pub fn go_char_right(&mut self) {
+        if self.position < self.value.len() {
+            self.position += 1;
+        } else {
+            self.position = self.value.len();
+        }
+    }
+    pub fn handle_control(&mut self, c: char) {
+        if !self.is_control_input && c.is_control() {
+            self.is_control_input = true
+        }
+        if self.is_control_input {
+            match c {
+                'D' => self.go_word_left(),
+                'C' => self.go_word_right(),
+                _ => { return; }
+            }
+            self.is_control_input = false
+        }
+
+        match c {
+            'b' => self.go_word_left(),
+            'f' => self.go_word_right(),
+            _ => {}
+        }
+    }
+    pub fn go_word_left(&mut self) {
+        if self.position == 0 {
+            return;
+        }
+        let mut new_position = self.position;
+        while new_position > 0
+            && self
+                .value
+                .as_str()
+                .chars()
+                .nth(new_position - 1)
+                .unwrap()
+                .is_whitespace()
+        {
+            new_position -= 1;
+        }
+        while new_position > 0
+            && !self
+                .value
+                .as_str()
+                .chars()
+                .nth(new_position - 1)
+                .unwrap()
+                .is_whitespace()
+        {
+            new_position -= 1;
+        }
+        self.position = new_position;
+    }
+    pub fn go_word_right(&mut self) {
+        if self.position == self.value.len() {
+            return;
+        }
+        let mut new_position = self.position;
+        while new_position < self.value.len()
+            && self
+                .value
+                .as_str()
+                .chars()
+                .nth(new_position)
+                .unwrap()
+                .is_whitespace()
+        {
+            new_position += 1;
+        }
+        while new_position < self.value.len()
+            && !self
+                .value
+                .as_str()
+                .chars()
+                .nth(new_position)
+                .unwrap()
+                .is_whitespace()
+        {
+            new_position += 1;
+        }
+        self.position = new_position;
+    }
+    pub fn format(&self) -> String {
+        if self.position == self.value.len() {
+            format!("{}{}", &self.value.as_str(), White.underline().paint(" "))
+        } else {
+            format!(
+                "{}{}{}",
+                &self.value.as_str()[0..self.position],
+                White
+                    .underline()
+                    .paint(&self.value.as_str()[self.position..self.position + 1]),
+                &self.value.as_str()[self.position + 1..]
+            )
+        }
+    }
+}


### PR DESCRIPTION
This adds support for moving left/right in the message editor, also supports `alt+left|right` to move between words.

`termion` added support for AltLeft & AltRight but it was removed before it was released, don't know what happened there... https://gitlab.redox-os.org/redox-os/termion/-/commit/d96c13560c2600fdb5100ff67ae98d65bf12c56c

I made a workaround by setting `is_control_input` and then handling the escaped character, maybe there's a better way 🤔 