### PR TITLE
🐛 Launch default editor for merge commit message

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -230,6 +230,7 @@ enum OutPath {
     EditMessage(PathBuf),
     RebaseTodo(PathBuf),
     AddPHunkEdit(PathBuf),
+    MergeMessage(PathBuf),
 }
 
 impl FromStr for OutPath {
@@ -242,6 +243,8 @@ impl FromStr for OutPath {
             Ok(OutPath::RebaseTodo(path))
         } else if path.ends_with(".git/addp-hunk-edit.diff") {
             Ok(OutPath::AddPHunkEdit(path))
+        } else if path.ends_with(".git/MERGE_MSG") {
+            Ok(OutPath::MergeMessage(path))
         } else {
             Err(format!("Must end with one of the following: \r\n\t{}\r\n\t{}\r\n\t{}\r\nGot the following path: {:?}", ".git/COMMIT_EDITMSG", ".git/rebase-merge/git-rebase-todo", ".git/addp-hunk-edit.diff", path))
         }
@@ -274,7 +277,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             Ok(())
         },
         Opt {
-            out_path: Some(OutPath::RebaseTodo(out_path) | OutPath::AddPHunkEdit(out_path)),
+            out_path: Some(OutPath::RebaseTodo(out_path) | OutPath::AddPHunkEdit(out_path) | OutPath::MergeMessage(out_path)),
             refspecs: None,
         } => {
             launch_default_editor(out_path);


### PR DESCRIPTION
When running `git merge`, 99% of the time i want to use the default message, this change makes it so merge messages are edited with default editor. Before this change, `emoji-commit` errored with
```
error: Invalid value for '<out-path>': Must end with one of the following: 
	.git/COMMIT_EDITMSG
	.git/rebase-merge/git-rebase-todo
	.git/addp-hunk-edit.diff
Got the following path: "<repo>/.git/MERGE_MSG"
error: There was a problem with the editor 'emoji-commit'.
Not committing merge; use 'git commit' to complete the merge.
```